### PR TITLE
Discard trips with zero or one stoptimes to prevent them from causing errors later.

### DIFF
--- a/transitime/src/main/java/org/transitime/gtfs/GtfsData.java
+++ b/transitime/src/main/java/org/transitime/gtfs/GtfsData.java
@@ -1446,6 +1446,12 @@ public class GtfsData {
 			// to have getScheduleTimesForTrip() update an already existing 
 			// Trip object.
 			List<ScheduleTime> scheduleTimesList = getScheduleTimesForTrip(trip);
+
+			if (scheduleTimesList.size() < 2) {
+				logger.warn("trip_id={} has zero or one stoptimes and will be discarded.", tripId);
+				continue;
+			}
+
 			trip.addScheduleTimes(scheduleTimesList); 
 						
 			if (isTripFrequencyBasedWithExactTimes(tripId)) {


### PR DESCRIPTION
Some GTFS feeds have trips with zero or one stoptimes, which causes errors in `GtfsData`.  Given that such trips have no real-world meaning, it is almost certainly safe to discard them after logging a warning.

Migrated from transitime/core#30.
