### PR TITLE
Fix IpcPrediction string format

### DIFF
--- a/transitclock/src/main/java/org/transitclock/ipc/data/IpcPrediction.java
+++ b/transitclock/src/main/java/org/transitclock/ipc/data/IpcPrediction.java
@@ -478,7 +478,7 @@ public class IpcPrediction implements Serializable {
 						: "")
 				+ (!Float.isNaN(passengerFullness) ? ", psngrFullness="
 						+ StringUtils.twoDigitFormat(passengerFullness) : "")
-				+ ("isCanceled= "+isCanceled)
+				+ ", isCanceled=" + (isCanceled ? "t" : "f")
 				+ "]";
 	}
 


### PR DESCRIPTION
Change from `arrival=fisCanceled= false` to `arrival=f, isCanceled=f`