### PR TITLE
Adding in concurrent logic to help prevent ConcurrentModificationException

### DIFF
--- a/transitclock/src/main/java/org/transitclock/avl/AvlClient.java
+++ b/transitclock/src/main/java/org/transitclock/avl/AvlClient.java
@@ -17,6 +17,7 @@
 package org.transitclock.avl;
 
 import java.util.HashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,6 +80,7 @@ public class AvlClient implements Runnable {
 	public void run() {
 		// Put a try/catch around everything so that if unexpected exception 
 		// occurs an e-mail is sent and the avl client thread isn't killed.
+		ReentrantLock l = new ReentrantLock();
 		try {
 			// If the data is bad throw it out
 			String errorMsg = avlReport.validateData();
@@ -89,7 +91,7 @@ public class AvlClient implements Runnable {
 			}
 
 			// See if should filter out report
-			synchronized (avlReports) {
+			l.lock();
 				AvlReport previousReportForVehicle =
 						avlReports.get(avlReport.getVehicleId());
 
@@ -165,7 +167,7 @@ public class AvlClient implements Runnable {
 				// filter
 				// the next one
 				avlReports.put(avlReport.getVehicleId(), avlReport);
-			}
+
 
 			// Process the report
 			logger.info("Thread={} AvlClient processing AVL data {}", 
@@ -179,6 +181,9 @@ public class AvlClient implements Runnable {
 //			logger.error(Markers.email(),
 //					"For agencyId={} Exception {} for avlReport={}.",
 //					AgencyConfig.getAgencyId(), e.getMessage(), avlReport, e);
+		}
+		finally{
+			l.unlock();
 		}
 	}
 	

--- a/transitclock/src/main/java/org/transitclock/core/Indices.java
+++ b/transitclock/src/main/java/org/transitclock/core/Indices.java
@@ -18,6 +18,7 @@ package org.transitclock.core;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.transitclock.applications.Core;
 import org.transitclock.db.structs.ArrivalDeparture;
@@ -196,6 +197,8 @@ public class Indices implements Serializable {
 	 * @return The resulting Indices object
 	 */
 	public Indices increment(long epochTime) {
+		ReentrantLock l = new ReentrantLock();
+		l.lock();
 		++segmentIndex;
 		if (segmentIndex >= block.numSegments(tripIndex, stopPathIndex)) {
 			segmentIndex = 0;
@@ -217,6 +220,7 @@ public class Indices implements Serializable {
 				}
 			}
 		}
+		l.unlock();
 
 		return this;
 	}

--- a/transitclock/src/main/java/org/transitclock/utils/threading/NamedThread.java
+++ b/transitclock/src/main/java/org/transitclock/utils/threading/NamedThread.java
@@ -19,6 +19,7 @@ package org.transitclock.utils.threading;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +80,8 @@ public class NamedThread extends Thread {
 	 * @return
 	 */
 	private static String threadNameWithCounter(String name) {
-		synchronized (threadNameCountMap) {
+		ReentrantLock l = new ReentrantLock();
+		l.lock();
 			Integer count = threadNameCountMap.get(name);
 			if (count == null) {
 				count = 1;				
@@ -88,16 +90,19 @@ public class NamedThread extends Thread {
 				count++;			
 			}		
 			threadNameCountMap.put(name, count);
+			l.unlock();
 			return name + "-" + count;
-		}
 	}
 	
 	@Override
 	public void run() {
 		logger.debug("Created NamedThread {}", getName());
+		ReentrantLock l = new ReentrantLock();
 		try {
+			l.lock();
 			numAlive.incrementAndGet();
 			super.run();
+
 		} catch (Throwable t) {
 			// Log the problem but do so within a try/catch in case it is
 			// an OutOfMemoryError and need to exit even if get another
@@ -141,6 +146,7 @@ public class NamedThread extends Thread {
 				System.exit(-1);
 			}
 		} finally {
+			l.unlock();
 			numAlive.decrementAndGet();
 			logger.debug("Exiting NamedThread {}", getName());
 		}


### PR DESCRIPTION
Adding in concurrent logic to help prevent ConcurrentModificationException, also appears to have a very minor boon to performance.